### PR TITLE
Add `setupSFMC` for Android and lock version for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ dependencies:
 
 Add your `google-services.json` from your Firebase to `app/`.
 
+By default the icon used in notification is the app icon, but you can define other in `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<meta-data
+    android:name="SFCMNotificationIcon"
+    android:resource="@drawable/custom_icon_here" />
+```
+
 ### Setup iOS
 
 No additional setup is needed for iOS.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ dependencies:
 
 ### Setup Android
 
-Add your `google-services.json` from your Firebase to `app/`.
-
-By default the icon used in notification is the app icon, but you can define other in `android/app/src/main/AndroidManifest.xml`:
+1. [Connect Marketing Cloud Account to Your Android App](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/create-apps/create-apps-overview.html)
+2. Folow [Firebase guide](https://firebase.google.com/docs/android/setup#console) (just until step 3.1) to add your `google-services.json` to `app/` directory.
+3. (Optional) By default the icon used in notification is the app icon, but you can define other in `android/app/src/main/AndroidManifest.xml`:
 
 ```xml
 <meta-data
@@ -38,7 +38,82 @@ By default the icon used in notification is the app icon, but you can define oth
 
 ### Setup iOS
 
-No additional setup is needed for iOS.
+1. [Create a .p8 Auth Key File](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/get-started/get-started-provision.html)
+2. [Setup MobilePush Apps](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/get-started/get-started-setupapps.html)
+3. Enable push notifications in your target’s [Capabilities settings](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/assets/SDKConfigure6.png).
+4. Setup your `AppDelegate.swift` file to handle push notification.
+
+```swift
+import UIKit
+import Flutter
+import MarketingCloudSDK
+
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        GeneratedPluginRegistrant.register(with: self)
+        registerForRemoteNotification()
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        MarketingCloudSDK.sharedInstance().sfmc_setDeviceToken(deviceToken)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print(error)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    /** This delegate method offers an opportunity for applications with the "remote-notification" background mode to fetch appropriate new data in response to an incoming remote notification. You should call the fetchCompletionHandler as soon as you're finished performing that operation, so the system can accurately estimate its power and data cost.
+    This method will be invoked even if the application was launched or resumed because of the remote notification. The respective delegate methods will be invoked first. Note that this behavior is in contrast to application:didReceiveRemoteNotification:, which is not called in those cases, and which will not be invoked if this method is implemented. **/
+    override func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        MarketingCloudSDK.sharedInstance().sfmc_setNotificationUserInfo(userInfo)  
+        completionHandler(.newData)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    // The method will be called on the delegate when the user responded to the notification by opening the application, dismissing the notification or choosing a UNNotificationAction. The delegate must be set before the application returns from applicationDidFinishLaunching:.
+    @available(iOS 10.0, *)
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        // Required: tell the MarketingCloudSDK about the notification. This will collect MobilePush analytics
+        // and process the notification on behalf of your application.
+        MarketingCloudSDK.sharedInstance().sfmc_setNotificationRequest(response.notification.request)
+        completionHandler()
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    // The method will be called on the delegate only if the application is in the foreground. If the method is not implemented or the handler is not called in a timely manner then the notification will not be presented. The application can choose to have the notification presented as a sound, badge, alert and/or in the notification list. This decision should be based on whether the information in the notification is otherwise visible to the user.
+    @available(iOS 10.0, *)
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler(.alert)
+    }
+
+    private func registerForRemoteNotification() {
+        if #available(iOS 10.0, *) {
+            // For iOS 10 display notification (sent via APNS)
+            UNUserNotificationCenter.current().delegate = self
+
+            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+            UNUserNotificationCenter.current().requestAuthorization(
+                options: authOptions,
+                completionHandler: { _, _ in }
+            )
+        } else {
+            let settings: UIUserNotificationSettings =
+                UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
+            UIApplication.shared.registerUserNotificationSettings(settings)
+        }
+
+        UIApplication.shared.registerForRemoteNotifications()
+    }
+}
+```
 
 ### Setup Flutter
 
@@ -69,22 +144,22 @@ Future<void> setupSFMC() async {
 
 #### Other available methods
 ```dart
-	await SFMCSDK.setContactKey("<contact_id>"); // Set Contact Key for desired user
-	  
-	await SFMCSDK.enablePush(); // Enables PUSH for SDK 
-	await SFMCSDK.disablePush(); // Disables PUSH for SDK  
-	await SFMCSDK.pushEnabled(); // Returns if push is enabled or not
-	
-	await SFMCSDK.setAttribute("name", "Mark"); // Set a user attribute 
-	await SFMCSDK.clearAttribute("name"); // Removes a given user attribute  
-	  
-	await SFMCSDK.setTag("Barcelona"); // Set a user tag   
-	await SFMCSDK.removeTag("Barcelona"); // Removes a given user tag  
-	  
-	await SFMCSDK.enableVerbose(); // Enable native Verbose
-	await SFMCSDK.disableVerbose(); // Disable native Verbose
-	  
-	await SFMCSDK.sdkState(); // Returns the SDKState log
+await SFMCSDK.setContactKey("<contact_id>"); // Set Contact Key for desired user
+  
+await SFMCSDK.enablePush(); // Enables PUSH for SDK 
+await SFMCSDK.disablePush(); // Disables PUSH for SDK  
+await SFMCSDK.pushEnabled(); // Returns if push is enabled or not
+
+await SFMCSDK.setAttribute("name", "Mark"); // Set a user attribute 
+await SFMCSDK.clearAttribute("name"); // Removes a given user attribute  
+  
+await SFMCSDK.setTag("Barcelona"); // Set a user tag   
+await SFMCSDK.removeTag("Barcelona"); // Removes a given user tag  
+  
+await SFMCSDK.enableVerbose(); // Enable native Verbose
+await SFMCSDK.disableVerbose(); // Disable native Verbose
+  
+await SFMCSDK.sdkState(); // Returns the SDKState log
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -22,132 +22,44 @@ dependencies:
   sfmc_flutter: <latest_version>
 ```
 
-In your library add the following import:
-
-```dart
-import 'package:sfmc_flutter/sfmc_flutter.dart';
-```
-
 ## Getting started
-### Setup Android
-1. Add SFMCSdk to project-level `build.gradle`
-```gradle
-allprojects {  
-  repositories {  
-	  ...
-      maven {  
-		  url "https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/repository"  
-	  }  
-  }
-}
- ```
-2. Add SFMCSdk to app-level `app/build.gradle`
-```gradle
-implementation ("com.salesforce.marketingcloud:marketingcloudsdk:8.0.4")  
-implementation 'com.google.android.gms:play-services-location:17.1.0'  
-  
-implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"  
-implementation platform('com.google.firebase:firebase-bom:29.0.0')  
-implementation 'com.google.firebase:firebase-messaging:20.1.2'
- ```
-3. Add your `google-services.json` from your Firebase to `app/`.
-4. Open `app/src/main/<your_package_name>/MainActivity.kt` and add the following code.
 
-```kotlin
-...
-import io.flutter.embedding.android.FlutterActivity  
-import com.salesforce.marketingcloud.MarketingCloudSdk  
-import com.salesforce.marketingcloud.MCLogListener  
-import com.salesforce.marketingcloud.MarketingCloudConfig  
-import com.salesforce.marketingcloud.notifications.NotificationCustomizationOptions  
-import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk  
-import com.salesforce.marketingcloud.sfmcsdk.SFMCSdkModuleConfig  
-  
-  
-class MainActivity : FlutterActivity() {  
-    override fun onCreate(savedInstanceState: Bundle?) {  
-        super.onCreate(savedInstanceState)  
-        SFMCSdk.configure(applicationContext as Application, SFMCSdkModuleConfig.build {  
-  pushModuleConfig = MarketingCloudConfig.builder().apply {  
-				setApplicationId("<your_application_id>")  
-                setAccessToken("<your_access_token>")  
-                setSenderId("<your_sender_id>")  
-                setMarketingCloudServerUrl("<your_marketing_cloud_url>")  
-                setMid("<your_mid>")  
-                setNotificationCustomizationOptions(  
-                    NotificationCustomizationOptions.create(R.drawable.ic_notification_icon)  
-                )  
-            }.build(applicationContext)  
-        }) { initStatus ->  
-   }  
- }  
-}
-```
+### Setup Android
+
+Add your `google-services.json` from your Firebase to `app/`.
 
 ### Setup iOS
-1. Setup your `AppDelegate.swift` file with Marketing Cloud initialization.
-```swift
-import UIKit  
-import Flutter  
-import MarketingCloudSDK  
-  
-@UIApplicationMain  
-@objc class AppDelegate: FlutterAppDelegate {  
-    override func application(  
-        _ application: UIApplication,  
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?  
-    ) -> Bool {  
-        GeneratedPluginRegistrant.register(with: self)  
-        self.configureMarketingCloudSDK()  
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions)  
-    }  
-      
-    func configureMarketingCloudSDK() {  
-        let builder = MarketingCloudSDKConfigBuilder()  
-            .sfmc_setApplicationId("<your_application_id>")  
-            .sfmc_setAccessToken("<your_access_token>")  
-            .sfmc_setMarketingCloudServerUrl("<your_marketing_cloud_url>")  
-            .sfmc_setMid("<your_mid>")  
-            .sfmc_build()!  
-          
-        do {  
-            try MarketingCloudSDK.sharedInstance().sfmc_configure(with:builder)  
-            registerForRemoteNotification()  
-        } catch let error as NSError {  
-            
-        }  
-    }  
-      
-    override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {  
-        MarketingCloudSDK.sharedInstance().sfmc_setDeviceToken(deviceToken)  
-    }  
-    func registerForRemoteNotification() {  
-            if #available(iOS 10.0, *) {  
-                let center  = UNUserNotificationCenter.current()  
-  
-                center.requestAuthorization(options: [.sound, .alert, .badge]) { (granted, error) in  
- if error == nil{  
-                        UIApplication.shared.registerForRemoteNotifications()  
-                    }  
-                }  
-  
-            }  
-            else {  
-                UIApplication.shared.registerUserNotificationSettings(UIUserNotificationSettings(types: [.sound, .alert, .badge], categories: nil))  
-                UIApplication.shared.registerForRemoteNotifications()  
-            }  
-        }  
-      
-    override func applicationProtectedDataDidBecomeAvailable(_ application: UIApplication) {  
-        if(MarketingCloudSDK.sharedInstance().sfmc_isReady() == false) {  
-            self.configureMarketingCloudSDK()  
-        }  
-    }  
+
+No additional setup is needed for iOS.
+
+### Setup Flutter
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:sfmc_flutter/sfmc_flutter.dart';
+// and any others imports...
+
+void main() {
+  setupSFMC();
+  runApp(const MyApp());
+}
+
+Future<void> setupSFMC() async {
+  if (kDebugMode) {
+    await SFMCSDK.enableVerbose();
+  }
+  await SFMCSDK.setupSFMC(
+    appId: "{mc_application_id}",
+    accessToken: "{mc_access_token}",
+    mid: "{mid}",
+    sfmcURL: "{marketing_cloud_url}",
+    senderId: "{fcm_sender_id}",
+    delayRegistration: true,
+  );
 }
 ```
 
-### Flutter
-
+#### Other available methods
 ```dart
 	await SFMCSDK.setContactKey("<contact_id>"); // Set Contact Key for desired user
 	  

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,10 +46,13 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
-}
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.salesforce.marketingcloud:marketingcloudsdk:8.0.4"
-    implementation 'com.google.android.gms:play-services-location:17.1.0'
+    dependencies {
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+        implementation "com.salesforce.marketingcloud:marketingcloudsdk:8.0.6"
+        implementation 'com.google.android.gms:play-services-location:17.1.0'
+
+        implementation platform("com.google.firebase:firebase-bom:30.3.2")
+        implementation 'com.google.firebase:firebase-messaging'
+    }
 }

--- a/android/src/main/kotlin/com/dribba/sfmc_flutter/SfmcFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/dribba/sfmc_flutter/SfmcFlutterPlugin.kt
@@ -90,6 +90,8 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             result.success(setPushEnabled(true))
         } else if (call.method == "disablePush") {
             result.success(setPushEnabled(false))
+        } else if (call.method == "getPushToken") {
+            getPushToken(result::success)
         } else if (call.method == "sdkState") {
             getSDKState() { res ->
                 result.success(res)
@@ -209,7 +211,7 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     /*
-     * Verbose Management
+     * Token Management
      */
     fun pushEnabled(result: (Any?) -> Unit) {
         MarketingCloudSdk.requestSdk { sdk ->
@@ -226,6 +228,14 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         return true
     }
 
+    fun getPushToken(onResult: (String?) -> Unit) {
+        SFMCSdk.requestSdk { sdk ->
+            sdk.mp {
+                onResult(it.pushMessageManager.pushToken)
+            }
+        }
+    }
+
     /*
      * SDKState Management
      */
@@ -235,21 +245,13 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
     }
 
-    override fun onDetachedFromActivity() {
-        // TODO: Not yet implemented
-    }
+    override fun onDetachedFromActivity() = Unit
 
-    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        // TODO: Not yet implemented
-    }
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) = Unit
 
-    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity;
-    }
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) = Unit
 
-    override fun onDetachedFromActivityForConfigChanges() {
-        // TODO: Not yet implemented
-    }
+    override fun onDetachedFromActivityForConfigChanges() = Unit
 
     private fun getNotificationIcon(): Int {
         val appInfo = context

--- a/android/src/main/kotlin/com/dribba/sfmc_flutter/SfmcFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/dribba/sfmc_flutter/SfmcFlutterPlugin.kt
@@ -28,11 +28,22 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "sfmc_flutter")
         channel.setMethodCallHandler(this)
         context = flutterPluginBinding.applicationContext
-
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        if (call.method == "setContactKey") {
+        if (call.method == "setupSFMC") {
+            val appId = call.argument<String>("appId")
+            val accessToken = call.argument<String>("accessToken")
+            val mid = call.argument<String>("mid")
+            val sfmcURL = call.argument<String>("sfmcURL")
+            val senderId = call.argument<String>("senderId")
+
+            if (appId == null || accessToken == null || mid == null || sfmcURL == null || senderId == null) {
+                result.error("ARGS_NOT_ALLOWED", "ARGS_NOT_ALLOWED", "ARGS_NOT_ALLOWED");
+                return
+            }
+            result.success(setupSFMC(appId, accessToken, mid, sfmcURL, senderId))
+        } else if (call.method == "setContactKey") {
             val cKey = call.argument<String>("cId")
             if (cKey == null) {
                 result.error("ARGS_NOT_ALLOWED", "ARGS_NOT_ALLOWED", "ARGS_NOT_ALLOWED");
@@ -93,56 +104,25 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         channel.setMethodCallHandler(null)
     }
 
-    fun setupSFMC(appId: String, accessToken: String, mid: String, sfmcURL: String, locationEnabled: Boolean, inboxEnabled: Boolean, analyticsEnabled: Boolean, delayRegistration: Boolean) {
-        // Initialize logging _before_ initializing the SDK to avoid losing valuable debugging information.
-        if (BuildConfig.DEBUG) {
-            MarketingCloudSdk.setLogLevel(MCLogListener.VERBOSE)
-            MarketingCloudSdk.setLogListener(MCLogListener.AndroidLogListener())
-        }
+    fun setupSFMC(appId: String, accessToken: String, mid: String, sfmcURL: String, senderId: String): Boolean {
+        val notificationIcon = context.applicationInfo.icon
 
-        SFMCSdk.configure(context, SFMCSdkModuleConfig.build {
+        SFMCSdk.configure(context.applicationContext, SFMCSdkModuleConfig.build {
             pushModuleConfig = MarketingCloudConfig.builder().apply {
-                setApplicationId("{mc_application_id}")
-                setAccessToken("{mc_access_token}")
-                setSenderId("{fcm_sender_id}")
-                setMarketingCloudServerUrl("{marketing_cloud_url}")
-                setMid("{mid}")
+                setApplicationId(appId)
+                setAccessToken(accessToken)
+                setSenderId(senderId)
+                setMarketingCloudServerUrl(sfmcURL)
+                setMid(mid)
+                setNotificationCustomizationOptions(
+                    NotificationCustomizationOptions.create(notificationIcon)
+                )
                 // Other configuration options
-            }.build(context)
+            }.build(context.applicationContext)
         }) { initStatus ->
             // TODO handle initialization status
         }
-
-        SFMCSdk.configure(context, SFMCSdkModuleConfig.build {
-            pushModuleConfig = MarketingCloudConfig.builder().apply {
-                setApplicationId("")
-                setAccessToken("")
-                setSenderId("")
-                setMarketingCloudServerUrl("")
-                setMid("")
-            }.build(context)
-        }) { initStatus ->
-
-        }
-
-//        let builder = MarketingCloudSDKConfigBuilder ()
-//                .sfmc_setApplicationId(appId)
-//                .sfmc_setAccessToken(accessToken)
-//                .sfmc_setMarketingCloudServerUrl(mid)
-//                .sfmc_setMid(mid)
-//                .sfmc_setDelayRegistration(untilContactKeyIsSet:(delayRegistration ?? false) as NSNumber)
-//        .sfmc_setInboxEnabled((inboxEnabled ?? true) as NSNumber)
-//        .sfmc_setLocationEnabled((locationEnabled ?? true) as NSNumber)
-//        .sfmc_setAnalyticsEnabled((analyticsEnabled ?? true) as NSNumber)
-//        .sfmc_build()!
-//
-//        do {
-//            try MarketingCloudSDK.sharedInstance().sfmc_configure(with:builder)
-//                onDone(true, nil, nil);
-//            } catch let error as NSError {
-//                onDone(false, error.localizedDescription, error.code);
-//            }
-//        }
+        return true
     }
 
     /*
@@ -214,13 +194,13 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     /*
      * Verbose Management
      */
-    fun setupVerbose(status: Boolean): Boolean {
-        if (status) {
+    fun setupVerbose(isEnabled: Boolean): Boolean {
+        if (isEnabled) {
             MarketingCloudSdk.setLogLevel(MCLogListener.VERBOSE)
             MarketingCloudSdk.setLogListener(MCLogListener.AndroidLogListener())
         } else {
-            MarketingCloudSdk.setLogLevel(MCLogListener.VERBOSE)
-            MarketingCloudSdk.setLogListener(MCLogListener.AndroidLogListener())
+            MarketingCloudSdk.setLogLevel(MCLogListener.ERROR)
+            MarketingCloudSdk.setLogListener(null)
         }
         return true
     }
@@ -253,11 +233,11 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     override fun onDetachedFromActivity() {
-        TODO("Not yet implemented")
+        // TODO: Not yet implemented
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        TODO("Not yet implemented")
+        // TODO: Not yet implemented
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
@@ -265,6 +245,6 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
-        TODO("Not yet implemented")
+        // TODO: Not yet implemented
     }
 }

--- a/android/src/main/kotlin/com/dribba/sfmc_flutter/SfmcFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/dribba/sfmc_flutter/SfmcFlutterPlugin.kt
@@ -3,6 +3,7 @@ package com.dribba.sfmc_flutter
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.content.pm.PackageManager
 import androidx.annotation.NonNull
 import com.salesforce.marketingcloud.MCLogListener
 import com.salesforce.marketingcloud.MarketingCloudConfig
@@ -17,6 +18,8 @@ import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk
 import com.salesforce.marketingcloud.sfmcsdk.SFMCSdkModuleConfig
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+
+private const val SFMC_NOTIFICATION_ICON_KEY = "SFCMNotificationIcon"
 
 /** SfmcFlutterPlugin */
 class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
@@ -105,7 +108,7 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     fun setupSFMC(appId: String, accessToken: String, mid: String, sfmcURL: String, senderId: String): Boolean {
-        val notificationIcon = context.applicationInfo.icon
+        val notificationIcon = getNotificationIcon()
 
         SFMCSdk.configure(context.applicationContext, SFMCSdkModuleConfig.build {
             pushModuleConfig = MarketingCloudConfig.builder().apply {
@@ -246,5 +249,19 @@ class SfmcFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     override fun onDetachedFromActivityForConfigChanges() {
         // TODO: Not yet implemented
+    }
+
+    private fun getNotificationIcon(): Int {
+        val appInfo = context
+            .applicationContext
+            .packageManager
+            .getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
+
+        val metaData = appInfo.metaData
+        if (metaData.containsKey(SFMC_NOTIFICATION_ICON_KEY)) {
+            return metaData.getInt(SFMC_NOTIFICATION_ICON_KEY)
+        }
+
+        return appInfo.icon
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -62,10 +62,5 @@ flutter {
 }
 
 dependencies {
-    implementation ("com.salesforce.marketingcloud:marketingcloudsdk:8.0.4")
-    implementation 'com.google.android.gms:play-services-location:17.1.0'
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation platform('com.google.firebase:firebase-bom:29.1.0')
-    implementation 'com.google.firebase:firebase-analytics'
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -23,5 +23,8 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data
+            android:name="SFCMNotificationIcon"
+            android:resource="@drawable/ic_notification_icon" />
     </application>
 </manifest>

--- a/example/android/app/src/main/kotlin/com/dribba/sfmc_flutter_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/dribba/sfmc_flutter_example/MainActivity.kt
@@ -1,37 +1,5 @@
 package com.dribba.sfmc_flutter_example
 
-import android.app.Application
-import android.os.Bundle
-import android.os.PersistableBundle
-import android.util.Log
 import io.flutter.embedding.android.FlutterActivity
-import com.salesforce.marketingcloud.MarketingCloudSdk
-import com.salesforce.marketingcloud.MCLogListener
-import com.salesforce.marketingcloud.MarketingCloudConfig
-import com.salesforce.marketingcloud.notifications.NotificationCustomizationOptions
-import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk
-import com.salesforce.marketingcloud.sfmcsdk.SFMCSdkModuleConfig
 
-
-class MainActivity : FlutterActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        Log.d("myTag", "This is my message");
-
-        SFMCSdk.configure(applicationContext as Application, SFMCSdkModuleConfig.build {
-            pushModuleConfig = MarketingCloudConfig.builder().apply {
-                setApplicationId("")
-                setAccessToken("")
-                setSenderId("")
-                setMarketingCloudServerUrl("")
-                setMid("")
-                setNotificationCustomizationOptions(
-                        NotificationCustomizationOptions.create(R.drawable.ic_notification_icon)
-                )
-            }.build(applicationContext)
-        }) { initStatus ->
-
-        }
-    }
-
-}
+class MainActivity : FlutterActivity()

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C5BA8DC528CC4FB10038C12C /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		DD45BBE0A38F3AB9BE2ABEAD /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -102,6 +103,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				C5BA8DC528CC4FB10038C12C /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -372,6 +374,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = LLA8MKK3QD;
 				ENABLE_BITCODE = NO;
@@ -382,6 +387,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.dribba.fluttersdk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -501,6 +507,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = LLA8MKK3QD;
 				ENABLE_BITCODE = NO;
@@ -511,6 +520,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.dribba.fluttersdk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -524,6 +534,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = LLA8MKK3QD;
 				ENABLE_BITCODE = NO;
@@ -534,6 +547,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.dribba.fluttersdk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import MarketingCloudSDK
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,61 @@ import Flutter
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
+        registerForRemoteNotification()
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        MarketingCloudSDK.sharedInstance().sfmc_setDeviceToken(deviceToken)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print(error)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    /** This delegate method offers an opportunity for applications with the "remote-notification" background mode to fetch appropriate new data in response to an incoming remote notification. You should call the fetchCompletionHandler as soon as you're finished performing that operation, so the system can accurately estimate its power and data cost.
+    This method will be invoked even if the application was launched or resumed because of the remote notification. The respective delegate methods will be invoked first. Note that this behavior is in contrast to application:didReceiveRemoteNotification:, which is not called in those cases, and which will not be invoked if this method is implemented. **/
+    override func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        MarketingCloudSDK.sharedInstance().sfmc_setNotificationUserInfo(userInfo)  
+        completionHandler(.newData)
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    // The method will be called on the delegate when the user responded to the notification by opening the application, dismissing the notification or choosing a UNNotificationAction. The delegate must be set before the application returns from applicationDidFinishLaunching:.
+    @available(iOS 10.0, *)
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        // Required: tell the MarketingCloudSDK about the notification. This will collect MobilePush analytics
+        // and process the notification on behalf of your application.
+        MarketingCloudSDK.sharedInstance().sfmc_setNotificationRequest(response.notification.request)
+        completionHandler()
+    }
+
+    // MobilePush SDK: REQUIRED IMPLEMENTATION
+    // The method will be called on the delegate only if the application is in the foreground. If the method is not implemented or the handler is not called in a timely manner then the notification will not be presented. The application can choose to have the notification presented as a sound, badge, alert and/or in the notification list. This decision should be based on whether the information in the notification is otherwise visible to the user.
+    @available(iOS 10.0, *)
+    override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler(.alert)
+    }
+
+    private func registerForRemoteNotification() {
+        if #available(iOS 10.0, *) {
+            // For iOS 10 display notification (sent via APNS)
+            UNUserNotificationCenter.current().delegate = self
+
+            let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+            UNUserNotificationCenter.current().requestAuthorization(
+                options: authOptions,
+                completionHandler: { _, _ in }
+            )
+        } else {
+            let settings: UIUserNotificationSettings =
+                UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
+            UIApplication.shared.registerUserNotificationSettings(settings)
+        }
+
+        UIApplication.shared.registerForRemoteNotifications()
     }
 }

--- a/example/ios/Runner/Runner.entitlements
+++ b/example/ios/Runner/Runner.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,6 +51,9 @@ class _MyAppState extends State<MyApp> {
 
     await SFMCSDK.sdkState();
 
+    final pushToken = await SFMCSDK.getPushToken();
+    print("Token: ${pushToken}");
+
     await SFMCSDK.enableVerbose();
     Timer.periodic(Duration(seconds: 2), (timer) async {
       _platformVersion = (await SFMCSDK.sdkState())!;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,7 @@ class _MyAppState extends State<MyApp> {
         mid: "",
         sfmcURL:
             "",
+        senderId: "",
         delayRegistration: true);
     await SFMCSDK.setContactKey("");
     await SFMCSDK.enablePush();

--- a/ios/Classes/SwiftSfmcFlutterPlugin.swift
+++ b/ios/Classes/SwiftSfmcFlutterPlugin.swift
@@ -102,6 +102,8 @@ public class SwiftSfmcFlutterPlugin: NSObject, FlutterPlugin, MarketingCloudSDKU
             result(setPushEnabled(status: true));
         } else if call.method == "disablePush" {
             result(setPushEnabled(status: false));
+        } else if call.method == "getPushToken" {
+            result(getPushToken());
         } else if call.method == "sdkState" {
             result(getSDKState())
         } else if call.method == "enableVerbose" {
@@ -219,9 +221,14 @@ public class SwiftSfmcFlutterPlugin: NSObject, FlutterPlugin, MarketingCloudSDKU
     public func pushEnabled() -> Bool {
         return MarketingCloudSDK.sharedInstance().sfmc_pushEnabled()
     }
+
     public func setPushEnabled(status: Bool) -> Bool {
         MarketingCloudSDK.sharedInstance().sfmc_setPushEnabled(status)
         return true
+    }
+
+    public func getPushToken() -> String? {
+        return MarketingCloudSDK.sharedInstance().sfmc_deviceToken()
     }
     
     /*

--- a/ios/sfmc_flutter.podspec
+++ b/ios/sfmc_flutter.podspec
@@ -12,10 +12,9 @@ Flutter plugin for integrating Salesforce Marketing Cloud in Flutter apps, for b
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'MarketingCloudSDK'
-  s.platform = :ios, '13.0'
+  s.dependency 'MarketingCloudSDK', '7.6.0'
+  s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.swift_version = '5.0'
 end

--- a/lib/sfmc_flutter.dart
+++ b/lib/sfmc_flutter.dart
@@ -104,6 +104,9 @@ class SFMCSDK {
     return result;
   }
 
+  static Future<String?> getPushToken() =>
+    _channel.invokeMethod('getPushToken');
+
   /*
   * SDK State Management
   */


### PR DESCRIPTION
Firstly, thank you very much to provide this SFMC library.

This is a fix for error reported in issue #2, and some others proposals:

- Lock `MarketingCloudSDK` version to `7.6.0`
- Include FCM dependecies to simplify setup in Android
- Get custom notification icon from `AndroidManifest`'s meta data.